### PR TITLE
Some rubocop linter fixes

### DIFF
--- a/lib/darwin/sys/admin.rb
+++ b/lib/darwin/sys/admin.rb
@@ -5,10 +5,9 @@ require 'sys/admin/common'
 
 module Sys
   class Admin
-    private
-
     # :no-doc:
     BUF_MAX = 65536 # Max buf size for retry.
+    private_constant :BUF_MAX
 
     attach_function :getlogin_r, [:pointer, :int], :int
     attach_function :getpwnam_r, [:string, :pointer, :pointer, :size_t, :pointer], :int
@@ -17,8 +16,8 @@ module Sys
     attach_function :getgrgid_r, [:long, :pointer, :pointer, :size_t, :pointer], :int
     attach_function :getlastlogx, [:long, :pointer], :pointer
 
-    private_class_method :getlogin_r, :getpwnam_r, :getpwuid_r, :getgrnam_r
-    private_class_method :getgrgid_r, :getlastlogx
+    private_class_method :getlogin_r, :getpwnam_r, :getpwuid_r
+    private_class_method :getgrnam_r, :getgrgid_r, :getlastlogx
 
     # struct passwd from /usr/include/pwd.h
     class PasswdStruct < FFI::Struct
@@ -36,6 +35,8 @@ module Sys
       )
     end
 
+    private_constant :PasswdStruct
+
     # struct group from /usr/include/grp.h
     class GroupStruct < FFI::Struct
       layout(
@@ -45,6 +46,8 @@ module Sys
         :gr_mem, :pointer
       )
     end
+
+    private_constant :GroupStruct
 
     # I'm blending the timeval struct in directly here
     class LastlogxStruct < FFI::Struct
@@ -56,7 +59,7 @@ module Sys
       )
     end
 
-    public
+    private_constant :LastlogxStruct
 
     # Returns the login for the current process.
     #
@@ -185,8 +188,6 @@ module Sys
       groups
     end
 
-    private
-
     # Takes a GroupStruct and converts it to a Group object.
     def self.get_group_from_struct(grp)
       Group.new do |g|
@@ -196,6 +197,8 @@ module Sys
         g.members = grp[:gr_mem].read_array_of_string
       end
     end
+
+    private_class_method :get_group_from_struct
 
     # Takes a UserStruct and converts it to a User object.
     def self.get_user_from_struct(pwd)
@@ -223,6 +226,8 @@ module Sys
       user
     end
 
+    private_class_method :get_user_from_struct
+
     # Gets lastlog information for the given user.
     def self.get_lastlog_info(uid)
       lastlog = LastlogxStruct.new
@@ -233,5 +238,7 @@ module Sys
 
       ptr.null? ? nil : lastlog
     end
+
+    private_class_method :get_lastlog_info
   end
 end

--- a/lib/sys/admin.rb
+++ b/lib/sys/admin.rb
@@ -1,7 +1,7 @@
 module Sys
   class Admin
     # The version of the sys-admin library.
-    VERSION = '1.7.4'.freeze
+    VERSION = '1.7.5'.freeze
   end
 end
 

--- a/lib/sys/admin/common.rb
+++ b/lib/sys/admin/common.rb
@@ -9,8 +9,6 @@ module Sys
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
 
-    private
-
     attach_function :strerror, [:int], :string
 
     attach_function :getlogin, [], :string
@@ -30,8 +28,6 @@ module Sys
     private_class_method :getlogin, :getuid, :getpwnam, :getpwuid, :getpwent
     private_class_method :setpwent, :endpwent, :getgrgid, :getgrnam
     private_class_method :getgrent, :endgrent, :setgrent, :strerror
-
-    public
 
     # Error typically raised if any of the Sys::Admin methods fail.
     class Error < StandardError; end

--- a/test/test_sys_admin.rb
+++ b/test/test_sys_admin.rb
@@ -14,7 +14,7 @@ end
 
 class TC_Sys_Admin_All < Test::Unit::TestCase
   test "version is set to expected value" do
-    assert_equal('1.7.4', Sys::Admin::VERSION)
+    assert_equal('1.7.5', Sys::Admin::VERSION)
   end
 
   test "version constant is frozen" do


### PR DESCRIPTION
Mainly fixes some useless access modifiers, and properly makes things private that should be private.