### PR TITLE
Fix access modifiers in Linux version

### DIFF
--- a/lib/linux/sys/admin.rb
+++ b/lib/linux/sys/admin.rb
@@ -5,10 +5,9 @@ require 'sys/admin/common'
 
 module Sys
   class Admin
-    private
-
     # :no-doc:
     BUF_MAX = 65536 # Absolute max buffer size for retry attempts.
+    private_constant :BUF_MAX
 
     # I'm making some aliases here to prevent potential conflicts
     attach_function :open_c, :open, [:string, :int], :int
@@ -40,6 +39,8 @@ module Sys
       )
     end
 
+    private_constant :PasswdStruct
+
     # struct group from /usr/include/grp.h
     class GroupStruct < FFI::Struct
       layout(
@@ -50,6 +51,8 @@ module Sys
       )
     end
 
+    private_constant :GroupStruct
+
     # I'm blending the timeval struct in directly here
     class LastlogStruct < FFI::Struct
       layout(
@@ -59,7 +62,7 @@ module Sys
       )
     end
 
-    public
+    private_constant :LastlogStruct
 
     # Returns the login for the current process.
     #
@@ -204,8 +207,6 @@ module Sys
       groups
     end
 
-    private
-
     # Takes a GroupStruct and converts it to a Group object.
     def self.get_group_from_struct(grp)
       Group.new do |g|
@@ -215,6 +216,8 @@ module Sys
         g.members = grp[:gr_mem].read_array_of_string
       end
     end
+
+    private_class_method :get_group_from_struct
 
     # Takes a UserStruct and converts it to a User object.
     def self.get_user_from_struct(pwd)
@@ -241,6 +244,8 @@ module Sys
 
       user
     end
+
+    private_class_method :get_user_from_struct
 
     # Note: it seems that Linux, or at least Ubuntu, does not track logins
     # via GDM (Gnome Display Manager) for some reason, so this may not return
@@ -269,5 +274,7 @@ module Sys
 
       lastlog
     end
+
+    private_class_method :get_lastlog_info
   end
 end


### PR DESCRIPTION
This fixes the access modifiers by actually making methods private that were always supposed to be private.