### PR TITLE
Change method for getting login user name on Linux

### DIFF
--- a/lib/linux/sys/admin.rb
+++ b/lib/linux/sys/admin.rb
@@ -67,13 +67,7 @@ module Sys
     # Returns the login for the current process.
     #
     def self.get_login
-      buf = FFI::MemoryPointer.new(:char, 256)
-
-      if getlogin_r(buf, buf.size) != 0
-        raise Error, "getlogin_r function failed: " + strerror(FFI.errno)
-      end
-
-      buf.read_string
+      get_user(geteuid()).name
     end
 
     # Returns a User object for the given name or uid. Raises an error

--- a/lib/sys/admin/common.rb
+++ b/lib/sys/admin/common.rb
@@ -13,6 +13,7 @@ module Sys
 
     attach_function :getlogin, [], :string
     attach_function :getuid, [], :long
+    attach_function :geteuid, [], :long
     attach_function :getpwnam, [:string], :pointer
     attach_function :getpwuid, [:long], :pointer
     attach_function :getpwent, [], :pointer
@@ -25,8 +26,8 @@ module Sys
     attach_function :endgrent, [], :void
     attach_function :setgrent, [], :void
 
-    private_class_method :getlogin, :getuid, :getpwnam, :getpwuid, :getpwent
-    private_class_method :setpwent, :endpwent, :getgrgid, :getgrnam
+    private_class_method :getlogin, :getuid, :geteuid, :getpwnam, :getpwuid
+    private_class_method :getpwent, :setpwent, :endpwent, :getgrgid, :getgrnam
     private_class_method :getgrent, :endgrent, :setgrent, :strerror
 
     # Error typically raised if any of the Sys::Admin methods fail.


### PR DESCRIPTION
Apparently the `getlogin` and `getlogin_r` functions are not entirely reliable on Linux. From the Linux man page:

> Unfortunately, it is often rather easy to fool getlogin(). Sometimes it does not work at all, because some program messed up the utmp file. Often, it gives only the first 8 characters of the login name. The user currently logged in on the controlling terminal of our program need not be the user who started it. Avoid getlogin() for security-related purposes.

The intertubes suggest using `getpwuid` + `geteuid`. Since the `Admin.get_user` method already implements most of what we need, this changes the `Admin.get_login` method to simply be a wrapper around `Admin.get_user` with `geteuid` as the argument.