### PR TITLE
Add win32-security back to gemspec as dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ namespace :gem do
     require 'rubygems/package'
     spec = eval(IO.read('sys-admin.gemspec'))
     spec.signing_key = File.join(Dir.home, '.ssh', 'gem-private_key.pem')
-    Gem::Package.build(spec, true)
+    Gem::Package.build(spec)
   end
 
   desc "Install the sys-uname gem"

--- a/sys-admin.gemspec
+++ b/sys-admin.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain = ['certs/djberg96_pub.pem']
 
   spec.add_dependency('ffi', '~> 1.1')
+  spec.add_dependency('win32-security', '~> 0.5') if Gem.win_platform?
 
   spec.add_development_dependency('test-unit', '>= 2.5.0')
   spec.add_development_dependency('rake')


### PR DESCRIPTION
For some reason I removed the dependency on win32-security for Windows. This PR adds it back, since at the very least bundler will need it, and also github actions.