### PR TITLE
Allow lastlog to be disabled on Mac

### DIFF
--- a/lib/darwin/sys/admin.rb
+++ b/lib/darwin/sys/admin.rb
@@ -81,6 +81,9 @@ module Sys
     #    Sys::Admin.get_user('joe')
     #    Sys::Admin.get_user(501)
     #
+    # Set the :lastlog option to false if you want to ignore lastlog
+    # information and speed this method up considerably.
+    #
     def self.get_user(uid, options = {})
       buf  = FFI::MemoryPointer.new(:char, 1024)
       pbuf = FFI::MemoryPointer.new(PasswdStruct)
@@ -148,6 +151,9 @@ module Sys
 
     # Returns an array of User objects for each user on the system.
     #
+    # Note that on Darwin this method can be very slow. If you want to
+    # speed it up considerably by ignoring lastlog information then set
+    # the :lastlog option to false as part of the +options+ hash.
     #--
     # This method is somewhat slow on OSX because of the call to get
     # lastlog information. I'm not sure why.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'rspec'
+
+RSpec.configure do |config|
+  config.filter_run_excluding(:darwin) if Gem::Platform.local.os != 'darwin'
+end

--- a/spec/sys_admin_unix_spec.rb
+++ b/spec/sys_admin_unix_spec.rb
@@ -67,8 +67,11 @@ RSpec.describe Sys::Admin, :unix do
         expect(users).to all(be_kind_of(Sys::Admin::User))
       end
 
-      example "users does not accept any arguments" do
-        expect{ described_class.users(user_id) }.to raise_error(ArgumentError)
+      example "users accepts an optional lastlog argument" do
+        users = described_class.users(lastlog: false)
+        expect(users).to be_kind_of(Array)
+        expect(users).to all(be_kind_of(Sys::Admin::User))
+        expect(users.first.login_time).to be_nil
       end
     end
 

--- a/spec/sys_admin_unix_spec.rb
+++ b/spec/sys_admin_unix_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Sys::Admin, :unix do
         expect(users).to all(be_kind_of(Sys::Admin::User))
       end
 
-      example "users accepts an optional lastlog argument" do
+      example "users accepts an optional lastlog argument on darwin", :darwin => true do
         users = described_class.users(:lastlog => false)
         expect(users).to be_kind_of(Array)
         expect(users).to all(be_kind_of(Sys::Admin::User))

--- a/spec/sys_admin_unix_spec.rb
+++ b/spec/sys_admin_unix_spec.rb
@@ -4,7 +4,7 @@
 # Test suite for the Unix version of sys-admin. This test should be run
 # via the 'rake spec' task.
 ###############################################################################
-require 'rspec'
+require 'spec_helper'
 require 'sys/admin'
 
 RSpec.describe Sys::Admin, :unix do

--- a/spec/sys_admin_unix_spec.rb
+++ b/spec/sys_admin_unix_spec.rb
@@ -41,9 +41,8 @@ RSpec.describe Sys::Admin, :unix do
         expect(described_class.get_user(user_id)).to be_kind_of(Sys::Admin::User)
       end
 
-      example "get_user requires one argument only" do
+      example "get_user requires at least one argument" do
         expect{ described_class.get_user }.to raise_error(ArgumentError)
-        expect{ described_class.get_user(user, user) }.to raise_error(ArgumentError)
       end
 
       example "get_user requires a string or integer argument" do
@@ -68,7 +67,7 @@ RSpec.describe Sys::Admin, :unix do
       end
 
       example "users accepts an optional lastlog argument" do
-        users = described_class.users(lastlog: false)
+        users = described_class.users(:lastlog => false)
         expect(users).to be_kind_of(Array)
         expect(users).to all(be_kind_of(Sys::Admin::User))
         expect(users.first.login_time).to be_nil


### PR DESCRIPTION
Collecting lastlog information for users can be very slow. This PR updates the `users` and `get_user` methods to accept an optional hash that can take a `:lastlog` key. If set to false then the lastlog information is skipped.